### PR TITLE
Small typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Saved Profiles:
 
 # set the current git repository user to the home profile
 $ git user set home
-The user for the 'project' repository has been set too 'Edward Hyde <hyde@night.com>'
+The user for the 'project' repository has been set to 'Edward Hyde <hyde@night.com>'
 
 # list profiles again, notice how the current repository profile is now set
 $ git user


### PR DESCRIPTION
Changed from "too" to "to" in the readme. I'm assuming it came from the code itself somewhere, but it looks good in the code from what I can see.

`set.go:                 cli.Info("The user for the '%s' repository has been set to '%s <%s>'",`